### PR TITLE
fixed issue with relative path to trackdb file

### DIFF
--- a/trackhub/genome.py
+++ b/trackhub/genome.py
@@ -41,7 +41,10 @@ class Genome(HubComponent):
             return "Unconfigured <Genome> object"
         s = []
         s.append('genome %s' % self.genome)
-        s.append('trackDb %s' % self.trackdb.local_fn)
+        trackdb_relpath = os.path.relpath(self.trackdb.local_fn, 
+                                          start = os.path.dirname(
+                                                    self.parent.parent.local_fn)) #local_fn of hub file
+        s.append('trackDb %s' % trackdb_relpath)
         return '\n'.join(s) + '\n'
 
     def validate(self):


### PR DESCRIPTION
Hi daler,

I had some problems with the reference from the genomes file to the trackdb file. If generating the trackhub in any directory other than the current working directory, the reference will be broken after uploading the trackhub to its remote location.
Instead, giving the path of the trackdb relative to the hub file circumvents this problem. It is implemented here in a similar way as in the [hub file](https://github.com/daler/trackhub/blob/master/trackhub/hub.py) in line 104 - 106.

Best, Jakob
