### PR TITLE
Add exonNumbers parameter

### DIFF
--- a/trackhub/constants.py
+++ b/trackhub/constants.py
@@ -68,6 +68,15 @@ track_typespecific_fields = {
             set(['on', 'off'])),
 
         Parameter(
+            'exonNumbers',
+            """
+            on|off; show exons or blocks within features, mouseover shows exon and
+            intron numbers. (Default: on)
+            """,
+            # NOTE: BED 9
+            set(['on', 'off'])),
+
+        Parameter(
             'scoreFilter',
             """default score filter value for a track which excludes scores
             below threshold""",


### PR DESCRIPTION
I was trying to setup a trackHub and a) wanted to use the exonNumbers parameter and b) saw it wasn't in your list.

UCSC docs: https://genome.ucsc.edu/goldenpath/help/trackDb/trackDbHub.html#exonNumbers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/daler/trackhub/22)
<!-- Reviewable:end -->
