### PR TITLE
Avoid accessing g._html if it doesn't exist

### DIFF
--- a/trackhub/upload.py
+++ b/trackhub/upload.py
@@ -98,7 +98,7 @@ def upload_hub(host, user, hub, port=22, rsync_options='-azvrL --progress',
                 )
             )
 
-        if g._html:
+        if hasattr(g, '_html') and g._html:
             results.extend(
                 upload_file(
                     local_fn=g._html.local_fn,


### PR DESCRIPTION
While running the unittests I got a crash because g.html didn't exist, this handles that case...

though I didn't look into why g._html didn't exist, so maybe its the wrong solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/daler/trackhub/24)
<!-- Reviewable:end -->
