### PR TITLE
allow autoScale group

### DIFF
--- a/trackhub/parsed_params.py
+++ b/trackhub/parsed_params.py
@@ -93,10 +93,10 @@ param_defs = [
 
     Param(
         name="autoScale",
-        fmt=['autoScale <off/on>'],
-        types=['bigWig'],
+        fmt=['autoScale <off/on/group>'],
+        types=['bigWig', 'compositeTrack'],
         required=False,
-        validator=set(['on', 'off'])),
+        validator=set(['on', 'off', 'group'])),
 
     Param(
         name="bamColorMode",


### PR DESCRIPTION
BigWig tracks within a composite have a [nice group scaling feature](http://genome.ucsc.edu/goldenPath/help/trackDb/trackDbHub.html#bigWig_-_Signal_Graphing_Track_Settings). 

To set it, one requires:
- the option to set `autoScale` to a compositeTrack or a Track within a composite
- the option to set `autoScale` to "group"

Setting autoScale to a compositeTrack with different datatypes seems to have no adverse effect (tested with a `view` containing bigWigs, and a `view` containing bigNarrowPeaks).

However, settings autoScale group to a bigWig track outside of a composite prevents the hub from displaying (and no error message from UCSC either...). 