### PR TITLE
support arbitrary kwargs for Genome objects (including defaultPos)

### DIFF
--- a/trackhub/__init__.py
+++ b/trackhub/__init__.py
@@ -16,7 +16,7 @@ from .track import BaseTrack, Track, SubGroupDefinition, CompositeTrack, \
 from .version import version as __version__
 
 
-def default_hub(hub_name, genome, email, short_label=None, long_label=None):
+def default_hub(hub_name, genome, email, short_label=None, long_label=None, defaultPos=None):
     """
     Returns a fully-connected set of hub components using default filenames.
 
@@ -49,7 +49,7 @@ def default_hub(hub_name, genome, email, short_label=None, long_label=None):
         long_label=long_label,
         email=email)
 
-    genome = Genome(genome)
+    genome = Genome(genome, defaultPos=defaultPos)
     genomes_file = GenomesFile()
     trackdb = TrackDb()
     hub.add_genomes_file(genomes_file)

--- a/trackhub/__init__.py
+++ b/trackhub/__init__.py
@@ -37,6 +37,9 @@ def default_hub(hub_name, genome, email, short_label=None, long_label=None, defa
 
     long_label : str
         Long label for the hub. If None, defaults to the value of `short_label`.
+
+    defaultPos : str
+        Default position for the hub
     """
     if short_label is None:
         short_label = hub_name
@@ -49,7 +52,10 @@ def default_hub(hub_name, genome, email, short_label=None, long_label=None, defa
         long_label=long_label,
         email=email)
 
-    genome = Genome(genome, defaultPos=defaultPos)
+    genome_kwargs = {}
+    if defaultPos:
+        genome_kwargs['defaultPos'] = defaultPos
+    genome = Genome(genome, **genome_kwargs)
     genomes_file = GenomesFile()
     trackdb = TrackDb()
     hub.add_genomes_file(genomes_file)

--- a/trackhub/genome.py
+++ b/trackhub/genome.py
@@ -3,10 +3,11 @@ from __future__ import absolute_import
 import os
 from .validate import ValidationError
 from .base import HubComponent
+from . import constants
 
 
 class Genome(HubComponent):
-    def __init__(self, genome, trackdb=None, genome_file_obj=None):
+    def __init__(self, genome, trackdb=None, genome_file_obj=None, **kwargs):
         """
         Represents a 2-line genome stanza within a "genomes.txt" file.
 
@@ -14,7 +15,6 @@ class Genome(HubComponent):
 
         Parameters
         ----------
-
         genome : str
             One of the UCSC-supported assembly names (e.g., "hg38")
 
@@ -32,6 +32,13 @@ class Genome(HubComponent):
         if genome_file_obj:
             self.add_parent(genome_file_obj)
 
+        self._orig_kwargs = kwargs
+
+        self.track_field_order = []
+        self.track_field_order.extend(constants.track_fields['genome'])
+
+        self.add_params(**kwargs)
+
     @property
     def genome_file_obj(self):
         try:
@@ -43,6 +50,37 @@ class Genome(HubComponent):
         self.children = []
         self.add_child(trackdb)
         self.trackdb = self.children[0]
+
+    def add_params(self, **kw):
+        """
+        Add [possibly many] parameters to the Genome.
+
+        Parameters will be checked against known UCSC parameters and their
+        supported formats.
+        """
+        for k, v in kw.items():
+            if k not in self.track_field_order:
+                raise ParameterError(
+                    '"{0}" is not a valid parameter for {1} with '
+                    'tracktype {2}'
+                    .format(k, self.__class__.__name__, self.tracktype)
+                )
+            constants.param_dict[k].validate(v)
+
+        self._orig_kwargs.update(kw)
+        self.kwargs = self._orig_kwargs.copy()
+
+    def remove_params(self, *args):
+        """
+        Remove [possibly many] parameters from the Genome.
+
+        E.g.,
+
+        remove_params('color', 'visibility')
+        """
+        for a in args:
+            self._orig_kwargs.pop(a)
+        self.kwargs = self._orig_kwargs.copy()
 
     def __str__(self):
         try:
@@ -58,6 +96,15 @@ class Genome(HubComponent):
                 os.path.dirname(self.genome_file_obj.filename)
             )
         )
+
+        for name in self.track_field_order:
+            value = self.kwargs.pop(name, None)
+            if value is not None:
+                if constants.param_dict[name].validate(value):
+                    s.append("%s %s" % (name, value))
+
+        self.kwargs = self._orig_kwargs.copy()
+
         return '\n'.join(s) + '\n'
 
     def validate(self):

--- a/trackhub/parsed_params.py
+++ b/trackhub/parsed_params.py
@@ -37,6 +37,10 @@ TRACKTYPES = [
     # assembly tracks are not defined in the document; we need to add
     # separately.
     'assembly',
+
+    # neither are genome objects, but we want to support arguments like
+    # defaultPos so it needs to be added here.
+    'genome',
 ]
 
 # Tracks for which the definition specifies bigDataUrl
@@ -1060,7 +1064,7 @@ param_defs = [
     Param(
         'defaultPos',
         fmt='',
-        types=['assembly'],
+        types=['all','assembly', 'genome'],
         required=False,
         validator=validate.ucsc_position),
 
@@ -1089,3 +1093,8 @@ param_defs = [
 # - exonArrows
 # - exonNumbers
 #
+
+# NOTE: there are other allowed parameters for things like Assembly or Genome
+# objects that require more complexity to find/create/validate. For example,
+# trackDb filenames are figured out on the fly. Those params with extra
+# complexity are not included here.


### PR DESCRIPTION
Previously there was not a good way of setting the `defaultPos` for Genome objects the same way you could for Assembly objects. This allows arbitrary kwargs to be passed when creating a Genome.