### PR TITLE
Fix indentation, rm track_type_override

### DIFF
--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -81,13 +81,12 @@ Furthermore, the genomes.txt file's name is prefixed by the hub name.
 
 So far, the `trackdb` object has no tracks added:
 
-.. testcode::
+.. doctest::
 
-    print(trackdb)
-
-.. testoutput::
-    :options: +NORMALIZE_WHITESPACE
-    
+    >>> print(trackdb)
+    Traceback (most recent call last):
+      ...
+    ValueError: No Track objects specified
     
 
 Adding tracks

--- a/trackhub/constants.py
+++ b/trackhub/constants.py
@@ -21,3 +21,5 @@ for tracktype in observed_types:
     for param in param_defs:
         if tracktype in param.types:
             lst.append(param.name)
+
+INDENT = '    '

--- a/trackhub/test/test_parentonoff/expected/hg19/trackDb.txt
+++ b/trackhub/test/test_parentonoff/expected/hg19/trackDb.txt
@@ -13,30 +13,30 @@ compositeTrack on
     parent testcomposite on
     view view1
     visibility full
-    
-            track E003DNase
-            bigDataUrl http://egg2.wustl.edu/roadmap/data/byFileType/signal/consolidated/macs2signal/pval/E003-DNase.pval.signal.bigwig
-            shortLabel E003DNase
-            longLabel E003DNase
-            type bigWig
-            parent testviewtrack off
-            visibility full
-            subGroups view=view1
-    
-            track E004DNase
-            bigDataUrl http://egg2.wustl.edu/roadmap/data/byFileType/signal/consolidated/macs2signal/pval/E004-DNase.pval.signal.bigwig
-            shortLabel E004DNase
-            longLabel E004DNase
-            type bigWig
-            parent testviewtrack on
-            visibility full
-            subGroups view=view1
-    
-            track E005DNase
-            bigDataUrl http://egg2.wustl.edu/roadmap/data/byFileType/signal/consolidated/macs2signal/pval/E005-DNase.pval.signal.bigwig
-            shortLabel E005DNase
-            longLabel E005DNase
-            type bigWig
-            parent testviewtrack
-            visibility full
-            subGroups view=view1
+
+        track E003DNase
+        bigDataUrl http://egg2.wustl.edu/roadmap/data/byFileType/signal/consolidated/macs2signal/pval/E003-DNase.pval.signal.bigwig
+        shortLabel E003DNase
+        longLabel E003DNase
+        type bigWig
+        parent testviewtrack off
+        visibility full
+        subGroups view=view1
+
+        track E004DNase
+        bigDataUrl http://egg2.wustl.edu/roadmap/data/byFileType/signal/consolidated/macs2signal/pval/E004-DNase.pval.signal.bigwig
+        shortLabel E004DNase
+        longLabel E004DNase
+        type bigWig
+        parent testviewtrack on
+        visibility full
+        subGroups view=view1
+
+        track E005DNase
+        bigDataUrl http://egg2.wustl.edu/roadmap/data/byFileType/signal/consolidated/macs2signal/pval/E005-DNase.pval.signal.bigwig
+        shortLabel E005DNase
+        longLabel E005DNase
+        type bigWig
+        parent testviewtrack
+        visibility full
+        subGroups view=view1

--- a/trackhub/track.py
+++ b/trackhub/track.py
@@ -111,7 +111,7 @@ class SubGroupDefinition(object):
 class BaseTrack(HubComponent):
     def __init__(self, name, tracktype=None, short_label=None,
                  long_label=None, subgroups=None, source=None, filename=None,
-                 html_string=None, html_string_format="rst", track_type_override=None, **kwargs):
+                 html_string=None, html_string_format="rst", **kwargs):
         """
         Represents a single track stanza, base class for other track types.
 
@@ -169,12 +169,6 @@ class BaseTrack(HubComponent):
         html_string_format : 'html' or 'rst'
             Indicates the format of `html_string`. If `"html"`, then use as-is;
             if `"rst"` then convert ReST to HTML.
-
-        track_type_override : str
-            Composite tracks can specify a tracktype of their children, but we
-            also need to know that it's a composite track. For composite tracks,
-            this can be set to "compositeTrack":
-
         """
         source, filename = deprecation_handler(source, filename, kwargs)
         HubComponent.__init__(self)
@@ -191,8 +185,6 @@ class BaseTrack(HubComponent):
         self.track_field_order = []
         self.track_field_order = update_list(self.track_field_order,
                                              constants.track_fields['all'])
-
-        self.track_type_override = track_type_override
 
         # NOTE: when setting track type, it will update the track field order
         # according to the known params for that track...so
@@ -290,11 +282,7 @@ class BaseTrack(HubComponent):
         base_tracktype = tracktype.split()[0]
 
         fields = []
-        if self.track_type_override:
-            for t in self.track_type_override:
-                fields.extend(constants.track_fields[t])
-        else:
-            fields.extend(constants.track_fields[base_tracktype])
+        fields.extend(constants.track_fields[base_tracktype])
         self.track_field_order = update_list(self.track_field_order, fields)
 
     def add_trackdb(self, trackdb):
@@ -497,13 +485,12 @@ class CompositeTrack(BaseTrack):
         See :class:`BaseTrack` for details on arguments. There are no
         additional arguments supported by this class.
         """
-        super(CompositeTrack,
-              self).__init__(track_type_override=['compositeTrack',
-                                                  'subGroups'], *args,
-                             **kwargs)
+        super(CompositeTrack, self).__init__(*args, **kwargs)
 
         self.track_field_order = update_list(
             self.track_field_order, constants.track_fields['compositeTrack'])
+        self.track_field_order = update_list(
+            self.track_field_order, constants.track_fields['subGroups'])
 
         # TODO: are subtracks and views mutually exclusive, or can a composite
         # have both "view-ed" and "non-view-ed" subtracks?

--- a/trackhub/track.py
+++ b/trackhub/track.py
@@ -718,7 +718,7 @@ class AggregateTrack(BaseTrack):
 
     def add_subtrack(self, subtrack):
         """
-        Add a child :class:`SubTrack` to this aggregrate.
+        Add a child :class:`SubTrack` to this aggregate.
         """
         self.add_child(subtrack)
         self.subtracks.append(subtrack)

--- a/trackhub/track.py
+++ b/trackhub/track.py
@@ -582,12 +582,12 @@ class CompositeTrack(BaseTrack):
         for view in self.views:
             s.append("")
             for line in str(view).splitlines(False):
-                s.append('    ' + line)
+                s.append(constants.INDENT + line)
 
         for subtrack in self.subtracks:
             s.append("")
             for line in str(subtrack).splitlines(False):
-                s.append('    ' + line)
+                s.append(constants.INDENT + line)
         return "\n".join(s)
 
 
@@ -643,7 +643,7 @@ class ViewTrack(BaseTrack):
         for subtrack in self.subtracks:
             s.append("")
             for line in str(subtrack).splitlines(False):
-                s.append('        ' + line)
+                s.append(constants.INDENT + line)
         return '\n'.join(s)
 
 
@@ -692,7 +692,7 @@ class SuperTrack(BaseTrack):
         for subtrack in self.subtracks:
             s.append("")
             for line in str(subtrack).splitlines(False):
-                s.append(line)
+                s.append(constants.INDENT + line)
         return '\n'.join(s)
 
 
@@ -746,7 +746,7 @@ class AggregateTrack(BaseTrack):
         for subtrack in self.subtracks:
             s.append("")
             for line in str(subtrack).splitlines(False):
-                s.append('    ' + line)
+                s.append(constants.INDENT + line)
         return "\n".join(s)
 
 

--- a/trackhub/trackdb.py
+++ b/trackhub/trackdb.py
@@ -101,9 +101,14 @@ class TrackDb(HubComponent):
         self.add_parent(genome)
 
     def __str__(self):
+        self.validate()
         s = []
         for track in self._tracks:
-            s.append(str(track) + '\n')
+            for line in str(track).splitlines(False):
+                line = line.rstrip()
+                s.append(line)
+            s.append('')
+
         return '\n'.join(s)
 
     def validate(self):


### PR DESCRIPTION
This PR improves how indentation is handled and updates tests accordingly. 

Also rolled into this is the removal of the `track_type_override` arg for tracks, which previously only CompositeTrack was using. Other classes were using a different mechanism to update their allowed track types. With the removal of this argument, all classes use the same mechanism.