### PR TITLE
Universal Track Hub Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,12 @@ ci/trackhub-demo/
 dist/
 ci/hubCheck
 build
+figure_4_paper/
+env/
+*xlsx
+hubCheck
+*/staging/*
+*bb
+*bed
+all_tracks/
+*/*staging/*

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ hubCheck
 *bed
 all_tracks/
 */*staging/*
+*bigWig
+*bw
+example_hubs/

--- a/TESTING
+++ b/TESTING
@@ -1,0 +1,5 @@
+# builds the examples, puts them in example_hubs/
+ci/build_examples.py
+
+# check just the hic hub
+ci/hubCheck example_hubs/example_hic_hub/hic.hub.txt

--- a/ci/example_hubs/example_assembly_hub/source.py
+++ b/ci/example_hubs/example_assembly_hub/source.py
@@ -1,0 +1,74 @@
+import trackhub
+import re
+import sys
+import os
+import glob
+
+# In contrast to the example in the README, we do not use the
+# `trackhub.default_hub` function but instead build up the hub from its
+# component pieces.
+hub = trackhub.Hub(
+    "assembly_hub",
+    short_label="assembly_hub",
+    long_label="an example of an assembly hub",
+    email="none@example.com")
+
+# The major difference from a regular track hub is this object, which needs
+# to be added to the genomes_file object:
+genome = trackhub.Assembly(
+    genome="newOrg1",
+    twobit_file=os.path.join(trackhub.helpers.data_dir(), "newOrg1.2bit"),
+    organism="Big Foot",
+    defaultPos="chr1:0-1000000",
+    scientificName="Biggus Footus",
+    description="BigFoot V4",
+    html_string="BIGFOOT V4 INFO\n",
+    orderKey=4800
+)
+
+genomes_file = trackhub.GenomesFile()
+hub.add_genomes_file(genomes_file)
+
+# we also need to create a trackDb and add it to the genome
+trackdb = trackhub.TrackDb()
+genome.add_trackdb(trackdb)
+
+# add the genome to the genomes file here:
+genomes_file.add_genome(genome)
+
+# Find all bigwigs for this genome in the example data directory, and make
+# tracks for them
+for bw in glob.glob(os.path.join(trackhub.helpers.data_dir(), "*no1*.bw")):
+    name, _, _ = os.path.basename(bw).split(".")
+    track = trackhub.Track(
+        name=trackhub.helpers.sanitize(name),
+        source=bw,
+        tracktype='bigWig',
+        autoScale='on')
+    trackdb.add_tracks(track)
+
+# Same with bigBeds
+for bb in glob.glob(os.path.join(trackhub.helpers.data_dir(), "*no1*.bigBed")):
+    name, _ = os.path.basename(bb).split(".")
+    track = trackhub.Track(
+        name=trackhub.helpers.sanitize(name),
+        source=bb,
+        tracktype='bigBed')
+    trackdb.add_tracks(track)
+
+# Assembly hubs also need to have a Group specified. Here's how to do that:
+example_group = trackhub.groups.GroupDefinition(
+    "example_tracks",
+    label="Example Tracks",
+    priority=1,
+    default_is_closed=False)
+
+groups_file = trackhub.groups.GroupsFile([example_group])
+genome.add_groups(groups_file)
+
+# We can now add the "group" parameter to all the children of the trackDb
+for track in trackdb.children:
+    track.add_params(group="example_tracks")
+
+trackhub.upload.upload_hub(hub=hub, host='localhost',
+    remote_dir='example_hubs/example_assembly_hub')

--- a/ci/example_hubs/example_bam_hub/source.py
+++ b/ci/example_hubs/example_bam_hub/source.py
@@ -1,0 +1,21 @@
+import trackhub
+hub, genomes_file, genome, trackdb = trackhub.default_hub(
+     hub_name="bam",
+     short_label="bam",
+     long_label="bam",
+     genome="hg18",
+     defaultPos = "chr21:33038946-33039092",
+     email="eva.jason@nih.gov")
+
+track = trackhub.Track(
+     tracktype='bam',
+     name="bam",
+     description="bam ex. 1: 1000 genomes read alignments (individual na12878)",
+     pairEndsByName=".",
+     pairSearchRange='10000',
+     chromosomes='chr21',
+     maxWindowToDraw='200000',
+     visibility='pack',
+     bigDataUrl='http://genome.ucsc.edu/goldenPath/help/examples/bamExample.bam')
+trackdb.add_tracks(track)
+trackhub.upload.upload_hub(hub=hub, host="localhost", remote_dir="example_hubs/example_bam_hub")

--- a/ci/example_hubs/example_bigBarChart_hub/source.py
+++ b/ci/example_hubs/example_bigBarChart_hub/source.py
@@ -1,0 +1,25 @@
+import trackhub
+hub, genomes_file, genome, trackdb = trackhub.default_hub(
+     hub_name='bigBarChart',
+     short_label='bigBarChart',
+     long_label='bigBarChart',
+     genome='hg38',
+     defaultPos='chr14:95081796-95436280',
+     email='eva.jason@nih.gov')
+track = trackhub.Track(
+     name = 'bigBarChart',
+     tracktype = 'bigBarChart',
+     visibility = 'full',
+     shortLabel = 'bigBarChart',
+     longLabel = 'Simple example bar chart track',
+     barChartBars = 'adiposeSubcut breastMamTissue colonTransverse muscleSkeletal wholeBlood',
+     barChartColors = '#FF6600 #33CCCC #CC9955 #AAAAFF #FF00BB',
+     barChartLabel = 'Tissues',
+     barChartMetric = 'median',
+     barChartUnit = 'RPKM',
+     bigDataUrl = 'http://genome.ucsc.edu/goldenPath/help/examples/barChart/hg38.gtexTranscripts.bb',
+     barChartMatrixUrl = 'http://genome.ucsc.edu/goldenPath/help/examples/barChart/exampleMatrix.txt',
+     barChartSampleUrl = 'http://genome.ucsc.edu/goldenPath/help/examples/barChart/exampleSampleData.txt')
+trackdb.add_tracks(track)
+
+trackhub.upload.upload_hub(hub=hub, host='localhost', remote_dir='example_hubs/example_bigBarChart_hub')

--- a/ci/example_hubs/example_bigChain_hub/source.py
+++ b/ci/example_hubs/example_bigChain_hub/source.py
@@ -1,0 +1,20 @@
+import trackhub
+
+hub, genomes_file, genome, trackdb = trackhub.default_hub(
+     hub_name='bigChain',
+     short_label='bigChain',
+     long_label='bigChain',
+     genome='hg38',
+     defaultPos = 'chr22:1-150754',
+     email='eva.jason@nih.gov')
+
+track = trackhub.Track(
+     name = 'bigChain',
+     bigDataUrl = 'http://genome.ucsc.edu/goldenPath/help/examples/bigChain.bb',
+     shortLabel = 'bigChain',
+     longLabel ='bigChain Example Hub',
+     tracktype = 'bigChain',
+     visibility = 'pack')
+trackdb.add_tracks(track)
+
+trackhub.upload.upload_hub(hub=hub, host='localhost', remote_dir='example_hubs/example_bigChain_hub')

--- a/ci/example_hubs/example_bigGenePred_hub/source.py
+++ b/ci/example_hubs/example_bigGenePred_hub/source.py
@@ -1,0 +1,19 @@
+import trackhub
+
+hub, genomes_file, genome, trackdb = trackhub.default_hub(
+    hub_name='bigGenePred',
+    short_label='bigGenePred',
+    long_label='bigGenePred',
+    genome='hg38',
+    email='eva.jason@nih.gov')
+
+track = trackhub.Track(
+    name='bigGenePred',
+    bigDataUrl = 'http://genome.ucsc.edu/goldenPath/help/examples/bigGenePredEx4.bb',
+    shortLabel = 'bigGenePred',
+    longLabel ='bigGenePred',
+    tracktype = 'bigGenePred',
+    visibility = 'pack')
+trackdb.add_tracks(track)
+
+trackhub.upload.upload_hub(hub=hub, host='localhost', remote_dir='example_hubs/example_bigGenePred_hub')

--- a/ci/example_hubs/example_bigInteract_hub/source.py
+++ b/ci/example_hubs/example_bigInteract_hub/source.py
@@ -1,0 +1,23 @@
+import trackhub
+
+hub, genomes_file, genome, trackdb = trackhub.default_hub(
+    hub_name="bigInteract",
+    defaultPos = 'chr3:63820967-63880091',
+    short_label="bigInteract",
+    long_label="bigInteract",
+    genome="hg19",
+    email="eva.jason@nih.gov")
+
+track = trackhub.Track(
+    name = 'bigInteract',
+    tracktype = 'bigInteract',
+    bigDataUrl = 'http://genome.ucsc.edu/goldenPath/help/examples/interact/interactExample3.inter.bb',
+    shortLabel = 'bigInteract',
+    longLabel ='bigInteract',
+    visibility = 'pack',
+    spectrum = 'on',
+    scoreMin = '175',
+    maxHeightPixels = '300:150:20')
+trackdb.add_tracks(track)
+
+trackhub.upload.upload_hub(hub=hub, host='localhost',remote_dir='example_hubs/example_bigInteract_hub')

--- a/ci/example_hubs/example_bigLolly_hub/source.py
+++ b/ci/example_hubs/example_bigLolly_hub/source.py
@@ -1,0 +1,26 @@
+import trackhub
+
+trackhub.settings.VALIDATE = False
+hub, genome, genomes_file,trackdb = trackhub.default_hub(
+     hub_name='bigLolly',
+     short_label='bigLolly',
+     long_label='bigLolly',
+     genome='hg38',
+     defaultPos = 'chr21:25891755-25891870',
+     email='eva.jason@nih.gov')
+
+add_kwargs = {'yAxisLabel.1': '0 on 30,30,190 0',
+              'yAxisLabel.1' : '5 on 30,30,190 5'}
+
+track = trackhub.Track(
+     tracktype = 'bigLolly',
+     bigDataUrl= 'http://genome.ucsc.edu/goldenPath/help/examples/bigLollyExample3.bb',
+     name = 'bigLolly',
+     lollySizeField='lollySize',
+     visibility='full',
+     noStems='on',
+     lollyMaxSize=10,
+     **add_kwargs)
+trackdb.add_tracks(track)
+
+trackhub.upload.upload_hub(hub=hub, host='localhost', remote_dir='example_hubs/example_bigLolly_hub')

--- a/ci/example_hubs/example_bigMaf_hub/orig.py
+++ b/ci/example_hubs/example_bigMaf_hub/orig.py
@@ -1,0 +1,17 @@
+import trackhub
+
+hub, genome, genomes_file,trackdb = trackhub.default_hub(
+     hub_name='bigMaf',
+     short_label='bigMaf',
+     long_label='bigMaf',
+     genome='hg38',
+     email='eva.jason@nih.gov')
+
+track = trackhub.Track(
+     name = 'bigMaf',
+     frames= 'http://genome.ucsc.edu/goldenPath/help/examples/bigMafFrames.bb',
+     bigDataUrl = 'http://genome.ucsc.edu/goldenPath/help/examples/bigMaf.bb',
+     tracktype='bigMaf')
+trackdb.add_tracks(track)
+
+trackhub.upload.upload_hub(hub=hub, host='localhost',remote_dir='example_hubs/example_bigMaf_hub')

--- a/ci/example_hubs/example_bigMaf_hub/source.py
+++ b/ci/example_hubs/example_bigMaf_hub/source.py
@@ -1,0 +1,21 @@
+import trackhub
+
+hub, genome, genomes_file, trackdb = trackhub.default_hub(
+    hub_name="bigMaf",
+    short_label="bigMaf",
+    long_label="bigMaf",
+    genome="hg38",
+    email="eva.jason@nih.gov",
+)
+
+track = trackhub.Track(
+    name="bigMaf",
+    frames="http://genome.ucsc.edu/goldenPath/help/examples/bigMafFrames.bb",
+    bigDataUrl="http://genome.ucsc.edu/goldenPath/help/examples/bigMaf.bb",
+    tracktype="bigMaf",
+)
+trackdb.add_tracks(track)
+
+trackhub.upload.upload_hub(
+    hub=hub, host="localhost", remote_dir="example_hubs/example_bigMaf_hub"
+)

--- a/ci/example_hubs/example_bigNarrowPeak_hub/source.py
+++ b/ci/example_hubs/example_bigNarrowPeak_hub/source.py
@@ -1,0 +1,19 @@
+import trackhub
+
+hub, genomes_file, genome, trackdb = trackhub.default_hub(
+    hub_name="bigNarrowPeak",
+    short_label="bigNarrowPeak",
+    long_label="bigNarrowPeak",
+    genome="hg38",
+    email="eva.jason@nih.gov")
+
+track = trackhub.Track(
+    tracktype='bigNarrowPeak',
+    name='bigNarrowPeak',
+    bigDataUrl='http://genome.ucsc.edu/goldenPath/help/examples/bigNarrowPeak.bb',
+    shortLabel='bigNPk',
+    longLabel='bigNarrowPeakExample',
+    visibility='full')
+trackdb.add_tracks(track)
+
+trackhub.upload.upload_hub(hub=hub, host='localhost',remote_dir='example_hubs/example_bigNarrowPeak_hub')

--- a/ci/example_hubs/example_bigPsl_hub/source.py
+++ b/ci/example_hubs/example_bigPsl_hub/source.py
@@ -1,0 +1,16 @@
+import trackhub
+
+hub, genome, genomes_file,trackdb = trackhub.default_hub(
+    hub_name='bigPsl',
+    short_label='bigPsl',
+    long_label='bigPsl',
+    genome='hg38',
+    email='eva.jason@nih.gov')
+
+track = trackhub.Track(
+    name = 'bigPsl',
+    tracktype ='bigPsl',
+    bigDataUrl='http://genome.ucsc.edu/goldenPath/help/examples/bigPsl.bb')
+trackdb.add_tracks(track)
+
+trackhub.upload.upload_hub(hub=hub, host='localhost',remote_dir='example_hubs/example_bigPsl_hub')

--- a/ci/example_hubs/example_bigWig_hub/source.py
+++ b/ci/example_hubs/example_bigWig_hub/source.py
@@ -1,0 +1,20 @@
+import trackhub
+
+hub, genomes_file, genome, trackdb = trackhub.default_hub(
+    hub_name="bigWig",
+    defaultPos = 'chr21:33031597-33041570',
+    short_label="bigWig",
+    long_label="bigWig",
+    genome="hg19",
+    email="eva.jason@nih.gov")
+
+track = trackhub.Track(
+    name = 'bigWig',
+    tracktype = 'bigWig',
+    bigDataUrl = 'http://genome.ucsc.edu/goldenPath/help/examples/bigWigExample.bw',
+    shortLabel = 'Example Hub',
+    longLabel ='Example Hub',
+    visibility = 'full')
+trackdb.add_tracks(track)
+
+trackhub.upload.upload_hub(hub=hub, host='localhost',remote_dir='example_hubs/example_bigWig_hub')

--- a/ci/example_hubs/example_grouping_hub/source.py
+++ b/ci/example_hubs/example_grouping_hub/source.py
@@ -1,0 +1,232 @@
+import glob, os
+import trackhub
+
+# Initialize the components of a track hub, already connected together
+hub, genomes_file, genome, trackdb = trackhub.default_hub(
+    hub_name="grouping",
+    short_label='example grouping hub',
+    long_label='example grouping hub',
+    genome="hg38",
+    email="dalerr@niddk.nih.gov")
+
+# Subgroups provide a way of tagging tracks. If you give the same tag to
+# a bigwig and a bigbed, you can use that tag to select them both. This is
+# useful for, e.g., ChIP-seq tracks where the tag is "sample" or
+# "antibody", and you can select both the signal and the called peaks at
+# the same time.
+#
+# Here we're making some contrived subgroups just to illustrate their use.
+subgroups = [
+
+    # A subgroup to select the replicate number
+    trackhub.SubGroupDefinition(
+        name='num',
+        label='Number',
+        mapping={
+            '0': 'zero',
+            '1': 'one',
+            '2': 'two',
+        }
+    ),
+
+    # A contrived subgroup that will only tag it as "yes" if it's sample 1.
+    trackhub.SubGroupDefinition(
+        name='s1',
+        label='is_sample_1',
+        mapping={
+            'y': 'Yes',
+            'n': 'No',
+        }
+    ),
+
+    # While the two different views we create below are a good way of
+    # turning on/off the signal or regions in bulk, this subgroup allows us
+    # to sort the tracks by "name" and then by "kind". This is helpful for
+    # ChIP-seq experiments where you want to have peaks under the
+    # corresponding signal.
+    trackhub.SubGroupDefinition(
+        name='kind',
+        label='kind',
+        mapping={
+            'signal': 'signal',
+            'peak': 'peak',
+        }
+    ),
+
+]
+
+# Create the composite track
+composite = trackhub.CompositeTrack(
+    name='composite',
+    short_label='Signal and regions',
+
+    # The available options for dimensions are the `name` attributes of
+    # each subgroup. Start with dimX and dimY (which become axes of the
+    # checkbox matrix to select tracks), and then dimA, dimB, etc.
+    dimensions='dimX=num dimY=s1 dimA=kind',
+
+    # This enables a drop-down box under the checkbox matrix that lets us
+    # select whatever dimA is (here, "kind").
+    filterComposite='dimA',
+
+    # The availalbe options here are the `name` attributes of each subgroup.
+    sortOrder='num=+ kind=-',
+    tracktype='bigWig',
+    visibility='full',
+)
+
+# Add those subgroups to the composite track
+composite.add_subgroups(subgroups)
+
+# Add the composite track to the trackDb
+trackdb.add_tracks(composite)
+
+# CompositeTracks compose different ViewTracks. We'll make one ViewTrack
+# for signal, and one for bigBed regions.
+signal_view = trackhub.ViewTrack(
+    name='signalviewtrack',
+    view='signal',
+    visibility='full',
+    tracktype='bigWig',
+    short_label='Signal')
+
+regions_view = trackhub.ViewTrack(
+    name='regionsviewtrack',
+    view='regions',
+    visibility='dense',
+    tracktype='bigWig',
+    short_label='Regions')
+
+# These need to be added to the composite.
+composite.add_view(signal_view)
+composite.add_view(regions_view)
+
+# Next we will build a multiWig overlay track which will show an example of
+# the signal as multiple bigWigs overlaying each other.
+overlay = trackhub.AggregateTrack(
+    aggregate='transparentOverlay',
+    visibility='full',
+    tracktype='bigWig',
+    viewLimits='-2:2',
+    maxHeightPixels='8:80:128',
+    showSubtrackColorOnUi='on',
+    name='agg')
+
+# We'll create a SuperTrack to hold this one aggregate overlay track. It's
+# overkill to do this for one track, but it does demonstrate the
+# functionality.
+supertrack = trackhub.SuperTrack(
+    name='super',
+    short_label='Super track'
+)
+trackdb.add_tracks(supertrack)
+
+#
+# If we weren't using a SuperTrack, we would add this aggregate track to
+# the trackDb, like so:
+#
+# trackdb.add_tracks(overlay)
+#
+# But here we're adding it to the SuperTrack:
+supertrack.add_tracks(overlay)
+
+# Next, some helper functions:
+
+def subgroups_from_filename(fn):
+    """
+    This functions figures out subgroups based on the number in the
+    filename.  Subgroups provided to the Track() constructor is
+    a dictionary where keys are `name` attributes from the subgroups added
+    to the composite above, and values are keys of the `mapping` attribute
+    of that same subgroup.
+
+    Might be easier to cross-reference with the subgroups above, but an
+    example return value from this function would be::
+
+        {'s1': 'n', 'num': '2'}
+    """
+    number = os.path.basename(fn).split('.')[0].split('-')[-1]
+    if number == '1':
+        is_1 = 'y'
+    else:
+        is_1 = 'n'
+    if fn.endswith('bw'):
+        kind = 'signal'
+    else:
+        kind = 'peak'
+    track_subgroup = {
+        's1': is_1,
+        'num': number,
+        'kind': kind,
+    }
+    return track_subgroup
+
+
+def color_from_filename(fn):
+    """
+    Figure out a nice color for a track, depending on its filename.
+    """
+    # Due to how code is extracted from the docs and run during tests, we
+    # need to import again inside a function. You don't normally need this.
+    import trackhub
+
+    number = os.path.basename(fn).split('.')[0].split('-')[-1]
+    colors = {
+        '0': '#8C2B45',
+        '1': '#2E3440',
+        '2': '#6DBFA7',
+    }
+    return trackhub.helpers.hex2rgb(colors[number])
+
+
+# As in the README example, we grab all the example bigwigs
+for bigwig in glob.glob(os.path.join(trackhub.helpers.data_dir(), "*hg38*.bw")):
+    track = trackhub.Track(
+        name=trackhub.helpers.sanitize(os.path.basename(bigwig)),
+        source=bigwig,
+        visibility='full',
+        tracktype='bigWig',
+        viewLimits='-2:2',
+        maxHeightPixels='8:50:128',
+        subgroups=subgroups_from_filename(bigwig),
+        color=color_from_filename(bigwig),
+    )
+
+    # Note that we add the track to the *view* rather than the trackDb as
+    # we did in the README example.
+    signal_view.add_tracks(track)
+
+    # For the multiWig overlay track, we need to add the track there as
+    # well. However it needs a different name. We have all the pieces,
+    # might as well just make another track object:
+    track2 = trackhub.Track(
+        name=trackhub.helpers.sanitize(os.path.basename(bigwig)) + 'agg',
+        source=bigwig,
+        visibility='full',
+        tracktype='bigWig',
+        color=color_from_filename(bigwig),
+    )
+    overlay.add_subtrack(track2)
+
+# Same thing with the bigBeds. No overlay track to add these to, though.
+# Just to the regions_view ViewTrack.
+for bigbed in glob.glob(os.path.join(trackhub.helpers.data_dir(), '*hg38*.bigBed')):
+    track = trackhub.Track(
+        name=trackhub.helpers.sanitize(os.path.basename(bigbed)),
+        source=bigbed,
+        visibility='dense',
+        subgroups=subgroups_from_filename(bigbed),
+        color=color_from_filename(bigbed),
+        tracktype='bigBed',
+    )
+    regions_view.add_tracks(track)
+
+
+# Example of "uploading" the hub locally, to be pushed to github later:
+trackhub.upload.upload_hub(hub=hub, host='localhost', remote_dir='example_hubs/example_grouping_hub')
+
+# Example uploading to a web server (not run):
+if 0:
+    trackhub.upload.upload_hub(
+        hub=hub, host='example.com', user='username',
+        remote_dir='/var/www/example_hub')

--- a/ci/example_hubs/example_hic_hub/source.py
+++ b/ci/example_hubs/example_hic_hub/source.py
@@ -1,0 +1,19 @@
+import trackhub
+hub, genomes_file, genome, trackdb = trackhub.default_hub(
+     hub_name="hic",
+     defaultPos= 'chr21:32000000-35000000',
+     short_label="hic_example",
+     long_label="hic_example",
+     genome="hg19",
+     email="eva.jason@nih.gov")
+
+track = trackhub.Track(
+     name = 'examplehicTrack',
+     tracktype = 'hic',
+     visibility = 'dense',
+     url = 'http://hgdownload.soe.ucsc.edu/gbdb/hg19/bbi/hic/GSE63525_GM12878_insitu_primary+replicate_combined.hic',
+     shortLabel = 'hic example',
+     longLabel = 'This hic file shows in situ Hi-C data from Rao et al. (2014) on the GM12878 cell line')
+
+trackdb.add_tracks(track)
+trackhub.upload.upload_hub(hub=hub, host='localhost', remote_dir='example_hubs/example_hic_hub')

--- a/ci/example_hubs/example_htmldoc_hub/source.py
+++ b/ci/example_hubs/example_htmldoc_hub/source.py
@@ -1,0 +1,175 @@
+import glob, os
+from textwrap import dedent
+import trackhub
+
+# Initialize the components of a track hub, already connected together
+hub, genomes_file, genome, trackdb = trackhub.default_hub(
+    hub_name="htmldoc",
+    short_label='example htmldoc hub',
+    long_label='example htmldoc hub',
+    genome="hg38",
+    email="dalerr@niddk.nih.gov")
+
+# Create a composite track. The documentation we add here will also be used
+# for all child tracks that are added to the child ViewTracks.
+composite = trackhub.CompositeTrack(
+    name='composite',
+    short_label='Signal and regions',
+    tracktype='bigWig',
+    visibility='full',
+    html_string=dedent(
+    """
+    Composite track
+    ---------------
+
+    This is a composite track that groups together signal (bigWig format)
+    and regions (bigBed format) into a single configurable container.
+
+    See `here <https://genome.ucsc.edu/goldenPath/help/trackDb/trackDbHub.html#compositeTrack>`_
+    for details.
+
+    The following is a test of various ReStructured Text contstructs.
+
+    Here's a literal block::
+
+        #!/usr/bin/env python
+        import trackhub
+
+    Here's an example definition block:
+
+    :example definition:
+        Definition would go here.
+
+    A list:
+
+    - list item 1
+    - list item 2
+
+    A numbered list:
+
+    #. one
+    #. two
+
+        **bold**, *italic*, ``monospace``, all within a ReST block quote
+
+    A table:
+
+    ======== ========
+      col 1   col 2
+    ======== ========
+      item1   item2
+      item3   item4
+    ======== ========
+
+    See [1]_ for more.
+
+    .. [1] http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html
+    """),
+)
+
+# Add the composite track to the trackDb
+trackdb.add_tracks(composite)
+
+# A ViewTrack for signal.
+signal_view = trackhub.ViewTrack(
+    name='signalviewtrack',
+    view='signal',
+    visibility='full',
+    tracktype='bigWig',
+    short_label='Signal',
+    html_string=dedent(
+    '''
+    Signal view docs
+    ----------------
+    While a file for this HTML documentation is created and uploaded, it
+    will be overridden by the CompositeView's documentation.
+    '''
+    )
+)
+composite.add_view(signal_view)
+
+# This multiWig overlay track will shows multiple bigWigs overlaying each
+# other in the same track
+overlay = trackhub.AggregateTrack(
+    aggregate='transparentOverlay',
+    visibility='full',
+    tracktype='bigWig',
+    viewLimits='-2:2',
+    maxHeightPixels='8:80:128',
+    showSubtrackColorOnUi='on',
+    name='agg',
+    html_string=dedent(
+    '''
+    Overlay
+    -------
+    This is a transparent overlay aggregate track. Over in the `grouping
+    example hub <https://daler.github.io/trackhub/grouping.html>`_, we had
+    added the overlay track to a SuperTrack. In that case, the SuperTrack's
+    documentation would override this documentation.
+
+    However, in this example, we are adding the overlay track directly to
+    the TrackDb and so this documentation will be displayed.
+    '''),
+)
+
+trackdb.add_tracks(overlay)
+
+# As in the README example, we grab all the example bigwigs
+for bigwig in glob.glob(os.path.join(trackhub.helpers.data_dir(), "*hg38*.bw")):
+    track = trackhub.Track(
+        name=trackhub.helpers.sanitize(os.path.basename(bigwig)),
+        source=bigwig,
+        visibility='full',
+        tracktype='bigWig',
+        viewLimits='-2:2',
+        maxHeightPixels='8:50:128',
+        html_string=dedent(
+        '''
+        Track as part of composite
+        --------------------------
+        While the HTML file is uploaded for this track, UCSC currently
+        displays the composite track's HTML instead.
+
+        This track was from {}'''
+        .format(os.path.basename(bigwig))
+        ),
+    )
+    signal_view.add_tracks(track)
+
+    # For the multiWig overlay track, we need to add the track there as
+    # well. However it needs a different name. We have all the pieces,
+    # might as well just make another track object:
+    track2 = trackhub.Track(
+        name=trackhub.helpers.sanitize(os.path.basename(bigwig)) + 'agg',
+        source=bigwig,
+        visibility='full',
+        tracktype='bigWig',
+    )
+    overlay.add_subtrack(track2)
+
+
+# This is a single bigBed track we are adding directly to the TrackDb. This
+# track's documentation will be displayed.
+bigbed = glob.glob(os.path.join(trackhub.helpers.data_dir(), '*hg38*.bigBed'))[0]
+single_track = trackhub.Track(
+    name=trackhub.helpers.sanitize(os.path.basename(bigbed)) + '1',
+    source=bigbed,
+    visibility='dense',
+    tracktype='bigBed',
+    html_string=dedent(
+    '''
+    Track docs
+    ----------
+    Documentation for a single track. Since this track is added directly to
+    the trackdb, and not to a view or composite, its specific documentation
+    is retained.
+    ''')
+)
+trackdb.add_tracks(single_track)
+
+trackhub.upload.upload_hub(hub=hub, host='localhost', remote_dir='example_hubs/example_htmldoc_hub')
+
+if 0:
+    trackhub.upload.upload_hub(
+        hub=hub, host='example.com', user='username',
+        remote_dir='/var/www/example_hub')

--- a/ci/example_hubs/example_hub/source.py
+++ b/ci/example_hubs/example_hub/source.py
@@ -1,0 +1,55 @@
+import glob, os
+import trackhub
+
+# First we initialize the components of a track hub
+
+hub, genomes_file, genome, trackdb = trackhub.default_hub(
+    hub_name="myhub",
+    short_label='myhub',
+    long_label='myhub',
+    genome="hg38",
+    email="ryan.dale@nih.gov")
+
+# Next we add tracks for some bigWigs. These can be anywhere on the
+# filesystem; symlinks will be made to them. Here we use some example data
+# included with the trackhub package; in practice you'd point to your own
+# data.
+
+for bigwig in glob.glob('trackhub/test/data/sine-hg38-*.bw'):
+
+    # track names can't have any spaces or special characters. Since we'll
+    # be using filenames as names, and filenames have non-alphanumeric
+    # characters, we use the sanitize() function to remove them.
+
+    name = trackhub.helpers.sanitize(os.path.basename(bigwig))
+
+    # We're keeping this relatively simple, but arguments can be
+    # programmatically determined (color tracks based on sample; change scale
+    # based on criteria, etc).
+
+    track = trackhub.Track(
+        name=name,          # track names can't have any spaces or special chars.
+        source=bigwig,      # filename to build this track from
+        visibility='full',  # shows the full signal
+        color='128,0,5',    # brick red
+        autoScale='on',     # allow the track to autoscale
+        tracktype='bigWig', # required when making a track
+    )
+
+    # Each track is added to the trackdb
+
+    trackdb.add_tracks(track)
+
+# In this example we "upload" the hub locally. Files are created in the
+# "example_hub" directory, along with symlinks to the tracks' data files.
+# This directory can then be pushed to GitHub or rsynced to a server.
+
+trackhub.upload.upload_hub(hub=hub, host='localhost', remote_dir='example_hubs/example_hub')
+
+# Alternatively, we could upload directly to a web server (not run in this
+# example):
+
+if 0:
+    trackhub.upload.upload_hub(
+        hub=hub, host='example.com', user='username',
+        remote_dir='/var/www/example_hub')

--- a/ci/example_hubs/example_vcfTabix_hub/source.py
+++ b/ci/example_hubs/example_vcfTabix_hub/source.py
@@ -1,0 +1,19 @@
+import trackhub
+
+hub, genome, genomes_file,trackdb = trackhub.default_hub(
+    hub_name = 'vcfTabix',
+    short_label = 'vcfTabix_example',
+    long_label='vcfTabix_example',
+    genome='hg19',
+    defaultPos = 'chr21:33034804-33037719',
+    email='eva.jason@nih.gov')
+
+track = trackhub.Track(
+    tracktype = 'vcfTabix',
+    name="VCF_Example_One",
+    chromosomes='chr21',
+    visibility='pack',
+    url='http://genome.ucsc.edu/goldenPath/help/examples/vcfExample.vcf.gz')
+trackdb.add_tracks(track)
+
+trackhub.upload.upload_hub(hub=hub, host='localhost',remote_dir='example_hubs/example_vcfTabix_hub')

--- a/composite_tests/test_1.py
+++ b/composite_tests/test_1.py
@@ -1,0 +1,47 @@
+"""test_1.py: write a test that creates a composite track that sets bigwig parameters to be inherited by child tracks."""
+
+import trackhub
+trackhub.settings.VALIDATE = True
+hub, genomes_file, genome, trackdb = trackhub.default_hub(
+    hub_name="test_1",
+    defaultPos='chr1:1-5000',
+    genome="hg38",
+    email="eva.jason@nih.gov")
+
+composite = trackhub.CompositeTrack(
+    name='composite_test1',
+    short_label='test1',
+    tracktype='bigWig',
+    autoScale='on',
+    color='119,10,233',
+    viewLimits='5:50',
+    visibility='full'
+)
+trackdb.add_tracks(composite)
+
+bw_view = trackhub.ViewTrack(
+    name='viewtrack',
+    view='signal',
+    tracktype='bigWig',
+    viewLimits='5:50',
+    short_label='view'
+)
+composite.add_view(bw_view)
+
+track0 = trackhub.Track(
+    name='sine0',
+    source='/data/NICHD-core0/infrastructure/trackhub/trackhub/test/data/sine-hg38-0.bedgraph.bw',
+    visibility='full',
+    color='124, 233, 10',
+    tracktype='bigWig',
+)
+bw_view.add_tracks(track0)
+
+track1 = trackhub.Track(
+    name='sine1',
+    source='/data/NICHD-core0/infrastructure/trackhub/trackhub/test/data/sine-hg38-1.bedgraph.bw',
+    visibility='full',
+    tracktype='bigWig',
+)
+bw_view.add_tracks(track1)
+trackhub.upload.upload_hub(staging = 'staging', hub=hub, host="biowulf.nih.gov", remote_dir="/data/NICHD-core0/datashare/example_hubs/composite")

--- a/composite_tests/test_2.py
+++ b/composite_tests/test_2.py
@@ -1,0 +1,44 @@
+"""test_2.py:composite, set composite's tracktype and include a parameter from that tracktype (e.g. for bigwig, viewLimits or something)"""
+
+import trackhub
+
+hub, genomes_file, genome, trackdb = trackhub.default_hub(
+    hub_name="test_1",
+    genome="hg38",
+    email="eva.jason@nih.gov")
+
+composite = trackhub.CompositeTrack(
+    name='composite_test1',
+    short_label='test1',
+    tracktype='bigWig',
+    autoScale='on',
+    viewLimits='10:50',
+    visibility='full'
+)
+trackdb.add_tracks(composite)
+
+bw_view = trackhub.ViewTrack(
+    name='viewtrack',
+    view='signal',
+    visibility='full',
+    tracktype='bigWig',
+    short_label='view'
+)
+composite.add_view(bw_view)
+
+track0 = trackhub.Track(
+    name='sine0',
+    source='/data/NICHD-core0/infrastructure/trackhub/trackhub/test/data/sine-hg38-0.bedgraph.bw',
+#visibility='full',
+    tracktype='bigWig',
+)
+bw_view.add_tracks(track0)
+
+track1 = trackhub.Track(
+    name='sine1',
+    source='/data/NICHD-core0/infrastructure/trackhub/trackhub/test/data/sine-hg38-1.bedgraph.bw',
+#    visibility='full',
+    tracktype='bigWig',
+)
+bw_view.add_tracks(track1)
+trackhub.upload.upload_hub(staging = 'staging', hub=hub, host="biowulf.nih.gov", remote_dir="/data/NICHD-core0/datashare/example_hubs/composite")

--- a/composite_tests/test_3.py
+++ b/composite_tests/test_3.py
@@ -1,0 +1,43 @@
+"""test_3.py:composite, don't set composite's tracktype but set view's tracktype, along with parameter for that tracktype."""
+
+import trackhub
+
+hub, genomes_file, genome, trackdb = trackhub.default_hub(
+    hub_name="test_3",
+    genome="hg38",
+    email="eva.jason@nih.gov")
+
+composite = trackhub.CompositeTrack(
+    name='composite_test1',
+    short_label='test1',
+    autoScale='on',
+    visibility='full'
+)
+trackdb.add_tracks(composite)
+
+bw_view = trackhub.ViewTrack(
+    name='viewtrack',
+    view='signal',
+    visibility='full',
+    tracktype='bigWig',
+    short_label='view',
+    viewLimits='10:50'
+)
+composite.add_view(bw_view)
+
+track0 = trackhub.Track(
+    name='sine0',
+    source='/data/NICHD-core0/infrastructure/trackhub/trackhub/test/data/sine-hg38-0.bedgraph.bw',
+#visibility='full',
+    tracktype='bigWig',
+)
+bw_view.add_tracks(track0)
+
+track1 = trackhub.Track(
+    name='sine1',
+    source='/data/NICHD-core0/infrastructure/trackhub/trackhub/test/data/sine-hg38-1.bedgraph.bw',
+#    visibility='full',
+    tracktype='bigWig',
+)
+bw_view.add_tracks(track1)
+trackhub.upload.upload_hub(staging = 'staging', hub=hub, host="biowulf.nih.gov", remote_dir="/data/NICHD-core0/datashare/example_hubs/composite")

--- a/composite_tests/test_4.py
+++ b/composite_tests/test_4.py
@@ -1,0 +1,45 @@
+"""test_4.py:composite track, where composite's tracktype is *different* from the view's tracktype"""
+
+import trackhub
+
+hub, genomes_file, genome, trackdb = trackhub.default_hub(
+    hub_name="test_3",
+    genome="hg38",
+    defaultPos='chr1:1-10000',
+    email="eva.jason@nih.gov")
+
+composite = trackhub.CompositeTrack(
+    name='composite_test1',
+    short_label='test1',
+    autoScale='on',
+    visibility='full',
+    tracktype="bigBed"
+)
+trackdb.add_tracks(composite)
+
+bw_view = trackhub.ViewTrack(
+    name='viewtrack',
+    view='signal',
+    visibility='full',
+    tracktype='bigWig',
+    short_label='view',
+    viewLimits='10:50'
+)
+composite.add_view(bw_view)
+
+track0 = trackhub.Track(
+    name='sine0',
+    source='/data/NICHD-core0/infrastructure/trackhub/trackhub/test/data/sine-hg38-0.bedgraph.bw',
+#visibility='full',
+    tracktype='bigWig',
+)
+bw_view.add_tracks(track0)
+
+track1 = trackhub.Track(
+    name='sine1',
+    source='/data/NICHD-core0/infrastructure/trackhub/trackhub/test/data/sine-hg38-1.bedgraph.bw',
+#    visibility='full',
+    tracktype='bigWig',
+)
+bw_view.add_tracks(track1)
+trackhub.upload.upload_hub(staging = 'staging', hub=hub, host="biowulf.nih.gov", remote_dir="/data/NICHD-core0/datashare/example_hubs/composite")

--- a/trackhub/constants.py
+++ b/trackhub/constants.py
@@ -9,7 +9,7 @@ param_dict = {i.name: i for i in param_defs}
 
 # These should at least be first...
 initial_params = ['track', 'bigDataUrl', 'shortLabel', 'longLabel', 'type']
-
+trackhub_specific = ["source", "tracktype","name"]
 track_fields = {i: initial_params[:] for i in TRACKTYPES}
 
 observed_types = set()

--- a/trackhub/parsed_params.py
+++ b/trackhub/parsed_params.py
@@ -834,6 +834,12 @@ param_defs = [
         types=['bam'],
         required=False,
         validator=int),
+    Param(
+        name="speciesOrder",
+        fmt=['speciesOrder <#>'],
+        types=['bigMaf'],
+        required=False,
+        validator=str),
 
     # NOTE in the spec there is "parent_container", "parent_supertrack", and
     # "parent". The reason appears to be so that there are unique div

--- a/trackhub/test/ad_hoc_test.py
+++ b/trackhub/test/ad_hoc_test.py
@@ -1,0 +1,37 @@
+# To run a single test that matches a string, use:
+#
+#   pytest ad_hoc_test.py -k <string>
+
+from trackhub.track import ViewTrack, CompositeTrack, ParameterError
+import pytest
+
+def test_view_params():
+    # ViewTracks are required to have a tracktype kwarg, so this should raise
+    # track.ParameterError
+    with pytest.raises(ParameterError):
+        v = ViewTrack(view='testing', name='testnameview')
+
+def test_view_track_allows_bigwig_kwargs():
+    v = ViewTrack(view='testnameview', name='testview', tracktype='bigWig', viewLimits='5:50')
+    str(v)
+
+def test_composite_track_allows_bigwig_kwargs():
+    c = CompositeTrack(name='testnamecomp', tracktype='bigWig', viewLimits='5:50')
+    str(c)
+
+# Eva to test:
+# Does the browser allow a composite track to have no tracktype set?
+def test_composite_track_should_allow_no_track_type():
+    c = CompositeTrack(name='testnamecomp')
+    str(c)
+
+
+def test_bw_kwargs_color():
+    c = CompositeTrack(comp='test',name='testnamecomp',tracktype='bigWig',color='119,10,233')
+
+
+def test_example_passing():
+    assert 1 == 1
+
+def test_view_without_composite():
+

--- a/universal_trackhub.py
+++ b/universal_trackhub.py
@@ -1,65 +1,93 @@
 import pandas as pd
 import numpy as np
 import trackhub
+from collections import defaultdict
 
 # import argparse
 from openpyxl import load_workbook
 import xlrd
 import sys
 
-# excel_file = argparse.ArgumentParser(description='Process some integers.')
-# excel_file.add_argument('excel-file', metavar='e', type=str,nargs='?',help='path to excel file for track hub')
-# args = parser.parse_args()
-
 # file = sys.argv[1]
+# destination = sys.argv[2]
 
 file = "universal_trackhub.xlsx"
 
-# destination = sys.argv[2]
-
-# get the sheet names
-# there must be sheets named "genome" and "hub"
-# TODO: check that there are sheets names "genome" and "hub"
+# Get the sheet names from the Excel Workbook
 sheets = xlrd.open_workbook(file, on_demand=True).sheet_names()
 
 
 def sheet_to_dict(file, sheet):
-    """ read a  two columns sheet and make it into a dictionary with the first column as keys and the second as the values"""
+    """
+    Read a  two columns sheet and make it into a dictionary with the first
+    column as keys and the second as the values of a dictionary
+
+    Parameters
+    ----------
+    file : str
+        Name of the Excel file to be read
+
+    sheet : str
+        Name of sheet in the Excel file to be read
+
+    Returns
+    -------
+    dict
+        A dictionary of a two column sheet with the keys as the first column
+        and values as the second column
+    """
     sheet = pd.read_excel(file, sheet_name=sheet, header=None)
     sheet_dict = dict(sheet.values.tolist())
     return sheet_dict
 
 
-# there must be sheets named "genome" and "hub"
-# Make the hub
+# There must be a sheet named "hub"
 hub_dict = sheet_to_dict(file, sheet="hub")
-hub = trackhub.Hub(**hub_dict)
 
-# Make the genome
-# TODO: without assembly
-genome_dict = sheet_to_dict(file, sheet="genome")
-genome = trackhub.Assembly(**genome_dict)
+# If using an assembly, then there must be a "genome" sheet
+if "genome" in sheets:
 
-genomes_file = trackhub.GenomesFile()
-hub.add_genomes_file(genomes_file)
-trackdb = trackhub.TrackDb()
-genome.add_trackdb(trackdb)
-genomes_file.add_genome(genome)
+    hub = trackhub.Hub(**hub_dict)
+    sheets.remove("hub")
+    # Make the genome
+    genome_dict = sheet_to_dict(file, sheet="genome")
+    genome = trackhub.Assembly(**genome_dict)
 
-# we also need to create a trackDb and add it to the genome
-trackdb = trackhub.TrackDb()
-genome.add_trackdb(trackdb)
+    genomes_file = trackhub.GenomesFile()
+    hub.add_genomes_file(genomes_file)
 
-# all_tracks =  add the genome to the genomes file here:
-genomes_file.add_genome(genome)
+    trackdb = trackhub.TrackDb()
+    trackdb = trackhub.TrackDb()
 
-sheets.remove("hub")
-sheets.remove("genome")
+    genome.add_trackdb(trackdb)
+    genomes_file.add_genome(genome)
 
+    # Create a trackDb and add it to the genome
+    genome.add_trackdb(trackdb)
+
+    # Add the genome to the genomes file here:
+    genomes_file.add_genome(genome)
+    sheets.remove("genome")
+
+else:
+    hub, genomes_file, genome, trackdb = trackhub.default_hub(**hub_dict)
+
+# These dictionary keep track of all of the container tracks
 all_super_tracks = {}
 all_composite_tracks = {}
 all_view_tracks = {}
 all_aggregate_tracks = {}
+
+
+# ALL THE POSSIBLE WAYS TO ADD A TRACK
+# trackdb <- super track <- composite track <- view track <- aggregate track <- track
+# trackdb <- super track <- composite track <- aggregate track <- track
+# trackdb <- composite track <- aggregate track <- track
+# trackdb <- super track <- aggregate track <- track
+# trackdb <- super track <- composite track <- track
+# trackdb <- aggregate track <- track
+# trackdb <- composite track <- track
+# trackdb <- track
 
 if "super_config" in sheets:
     # takes a data frame and returns a list of dictionaries
@@ -71,90 +99,95 @@ if "super_config" in sheets:
         supertrack_object = trackhub.SuperTrack(**supertrack)
         all_super_tracks[supertrack["name"]] = supertrack_object
         trackdb.add_tracks(supertrack_object)
-    if "composite_config" in sheets:
-        # takes a data frame and returns a list of dictionaries
-        # the keys are the headers and the values are row values
-        list_of_composite_tracks_as_dict = pd.read_excel(
-            file, sheet_name="composite_config"
-        ).to_dict(orient="records")
-        for composite in list_of_composite_tracks_as_dict:
-            supertrack = composite["super"]
-            del composite["super"]
 
-            compositetrack_object = trackhub.CompositeTrack(**composite)
-            all_composite_tracks[composite["name"]] = compositetrack_object
-            all_super_tracks[supertrack].add_tracks(compositetrack_object)
-    if "view_config" in sheets:
-        list_of_view_tracks_as_dict = pd.read_excel(
-            file, sheet_name="view_config"
-        ).to_dict(orient="records")
-        for view in list_of_view_tracks_as_dict:
-            compositetrack = view["composite"]
-            del view["composite"]
-            viewtrack_object = trackhub.ViewTrack(**view)
-            all_view_tracks[view["name"]] = viewtrack_object
-            all_composite_tracks[compositetrack].add_tracks(viewtrack_object)
-
-elif "composite_config" in sheets:
+if "composite_config" in sheets:
+    # takes a data frame and returns a list of dictionaries
+    # the keys are the headers and the values are row values
     list_of_composite_tracks_as_dict = pd.read_excel(
         file, sheet_name="composite_config"
     ).to_dict(orient="records")
     for composite in list_of_composite_tracks_as_dict:
+        supertrack = composite["super"]
+        del composite["super"]
         compositetrack_object = trackhub.CompositeTrack(**composite)
         all_composite_tracks[composite["name"]] = compositetrack_object
-        trackdb.add_tracks(compositetrack_object)
-    if "view_config" in sheets:
-        list_of_view_tracks_as_dict = pd.read_excel(
-            file, sheet_name="view_config"
-        ).to_dict(orient="records")
-        for view in list_of_view_tracks_as_dict:
-            #new_dict = {key: val for key, val in view.items() if key != "composite"}
-            comp = view["composite"]
+        if supertrack in all_super_tracks:
+            all_super_tracks[supertrack].add_tracks(compositetrack_object)
+        else:
+            trackdb.add_tracks(compositetrack_object)
 
-            del view["composite"]
-            viewtrack_object = trackhub.ViewTrack(**new_dict)
-            all_view_tracks[view["name"]] = viewtrack_object
-            all_composite_tracks[view[comp]].add_tracks(viewtrack_object)
+if "view_config" in sheets:
+    list_of_view_tracks_as_dict = pd.read_excel(file, sheet_name="view_config").to_dict(
+        orient="records"
+    )
+    for view in list_of_view_tracks_as_dict:
+        composite = view["composite"]
+        del view["composite"]
+        viewtrack_object = trackhub.ViewTrack(**view)
+        all_view_tracks[view["name"]] = viewtrack_object
+        all_composite_tracks[composite].add_tracks(viewtrack_object)
 
-track_sheets = [item for item in sheets if "config" not in item]
-all_tracks_dict = []
-track_dicts = []
-for t in track_sheets:
-    #turns rows of sheet into list of dictionaries
-    track_dicts.extend(pd.read_excel(file, sheet_name=t).to_dict(orient="records"))
+if "aggregate_config" in sheets:
+    list_of_aggregate_tracks_as_dict = pd.read_excel(
+        file, sheet_name="aggregate_config"
+    ).to_dict(orient="records")
+    for agg in list_of_aggregate_tracks_as_dict:
+        container = agg["container"]
+        del agg["container"]
+        agg_object = trackhub.AggregateTrack(**agg)
+        all_aggregate_tracks[agg["name"]] = agg_object
+        if container in all_view_tracks:
+            all_view_tracks[container].add_tracks(agg_object)
+        if container in all_composite_tracks:
+            all_composite_tracks[container].add_tracks(agg_object)
+        if container in all_super_tracks:
+            all_super_tracks[container].add_tracks(agg_object)
+        else:
+            trackdb.add_tracks(agg_object)
+
+all_tracks_dict_list = []
+
 
 def prepare_track_dict(track_dictionary):
     new_dict = {}
-    for k,v in track_dictionary.items():
-        if not isinstance(v,str) and np.isnan(float(v)):
+    for k, v in track_dictionary.items():
+        if not isinstance(v, str) and np.isnan(float(v)):
             continue
         else:
-            new_dict[k]=v
-    #print(new_dict)
-    parameters = trackhub.constants.track_fields[new_dict['tracktype']][:]
-    #print(parameters)
-    parameters.extend(trackhub.constants.track_fields['all'][:])
-    parameters.extend(["source", "tracktype","name"])
-    track_dict_new = {k:v for k,v in new_dict.items() if k in parameters}
-    #print(track_dict_new)
+            new_dict[k] = v
+    parameters = trackhub.constants.track_fields[new_dict["tracktype"]][:]
+    parameters.extend(trackhub.constants.track_fields["all"][:])
+    parameters.extend(trackhub.constants.trackhub_specific)
+    track_dict_new = {k: v for k, v in new_dict.items() if k in parameters}
     return track_dict_new
-#trackhub.Track(**track_dict_new)
 
+
+for sheet in sheets:
+    if "config" not in sheet:
+        list_of_dicts = pd.read_excel(file, sheet_name=sheet).to_dict(orient="records")
+        all_tracks_dict_list.extend(list_of_dicts)
+
+# iterate through all of the tracks
 composite_to_subgroups_dict = {}
 track_to_subgroups = {}
-# iterate through all of the tracks
-subgroup_to_options={}
-for track_dict in track_dicts:
+subgroup_to_options = {}
+for track_dict in all_tracks_dict_list:
     # add the track to the appropriate container
     track = prepare_track_dict(track_dict)
     track = trackhub.Track(**track)
+    if "parent" in track_dict:
+        parent = track_dict["parent"]
+    else:
+        parent = "none"
 
-    if 'view' in track_dict:
-        all_view_tracks[track_dict['view']].add_tracks(track)
-    elif 'composite' in track_dict:
-        all_composite_tracks[track_dict['composite']].add_tracks(track)
-    elif 'supertrack' in track_dict:
-        all_super_tracks[track_dict['supertrack']].add_tracks(track)
+    if parent in all_aggregate_tracks:
+        all_aggregate_tracks[parent].add_tracks(track)
+    if parent in all_view_tracks:
+        all_view_tracks[parent].add_tracks(track)
+    if parent in all_composite_tracks:
+        all_composite_tracks[parent].add_tracks(track)
+    if parent in all_super_tracks:
+        all_super_tracks[parent].add_tracks(track)
     else:
         trackdb.add_tracks(track)
 
@@ -162,31 +195,32 @@ for track_dict in track_dicts:
     subgroups_set = set()
     # what about the case where there is a composite but no subgroups?
     # subgroups are present in composite track. is there is no composite track define then there can be no subgroups
-    if 'composite' in track_dict:
+    if "composite" in track_dict:
+        subgroup_to_options = defaultdict(set)
         subgroup_dict = {}
-        for k,v in track_dict.items():
-            # find items in dicitonary that start with subgroup
+        for k, v in track_dict.items():
+            # find items in dictionary that start with subgroup
             if "subgroup" in k:
+                # print(k)
 
-                new_subgroup = k.replace("subgroup_","")
-                #get the full set of subgroups for the track
-                if new_subgroup in subgroup_to_options:
-                    subgroup_to_options[new_subgroup].extend([v])
-                    subgroup_to_options[new_subgroup] = list(set(subgroup_to_options[new_subgroup]))
-                else:
-                    subgroup_to_options[new_subgroup] = [v]
-                #print(subgroup_to_options)
+                new_subgroup = k.replace("subgroup_", "")
+                # get the full set of subgroups for the track
+                # if new_subgroup in subgroup_to_options:
+                subgroup_to_options[new_subgroup] |= set([v])
+                # else:
+                #   subgroup_to_options[new_subgroup] = set([v])
+                # print(subgroup_to_options)
                 # keep track of subgroup and value for the track
                 subgroup_dict[new_subgroup] = v
         if len(subgroup_dict) == 0:
             continue
         # add the full set of subgroups the a dictioary the converts composite to subgroups
         # turn it into a list so it can be iterated on later
-        composite_to_subgroups_dict[track_dict['composite']] = subgroup_to_options
+        composite_to_subgroups_dict[track_dict["composite"]] = subgroup_to_options
         # add the dictionary pf subgroups to a dictionary that goes from track to subgroup
-        track_to_subgroups[track_dict['name']] = subgroup_dict
+        track_to_subgroups[track_dict["name"]] = subgroup_dict
 
-for composite,subgroup_options in composite_to_subgroups_dict.items():
+for composite, subgroup_options in composite_to_subgroups_dict.items():
     subgroups = []
 
     for subgroup_name, options in subgroup_options.items():
@@ -194,13 +228,10 @@ for composite,subgroup_options in composite_to_subgroups_dict.items():
         mapping_dict = {group: group for group in subgroup_options}
 
         s = trackhub.SubGroupDefinition(
-            name = subgroup_name,
-            label = subgroup_name,
-            mapping = mapping_dict)
+            name=subgroup_name, label=subgroup_name, mapping=mapping_dict
+        )
 
         subgroups.append(s)
     all_composite_tracks[composite].add_subgroups(subgroups)
-
-
 
 # trackhub.upload.upload_hub(hub=hub, host="helix.nih.gov", remote_dir=destination, staging=s)

--- a/universal_trackhub.py
+++ b/universal_trackhub.py
@@ -1,22 +1,23 @@
 import pandas as pd
+import numpy as np
 import trackhub
-#import argparse
+
+# import argparse
 from openpyxl import load_workbook
 import xlrd
 import sys
 
+# excel_file = argparse.ArgumentParser(description='Process some integers.')
+# excel_file.add_argument('excel-file', metavar='e', type=str,nargs='?',help='path to excel file for track hub')
+# args = parser.parse_args()
 
-#excel_file = argparse.ArgumentParser(description='Process some integers.')
-#excel_file.add_argument('excel-file', metavar='e', type=str,nargs='?',help='path to excel file for track hub')
-#args = parser.parse_args()
+# file = sys.argv[1]
 
-#file = sys.argv[1]
+file = "universal_trackhub.xlsx"
 
-file ='universal_trackhub.xlsx'
+# destination = sys.argv[2]
 
-#destination = sys.argv[2]
-
-#get the sheet names
+# get the sheet names
 # there must be sheets named "genome" and "hub"
 # TODO: check that there are sheets names "genome" and "hub"
 sheets = xlrd.open_workbook(file, on_demand=True).sheet_names()
@@ -28,12 +29,14 @@ def sheet_to_dict(file, sheet):
     sheet_dict = dict(sheet.values.tolist())
     return sheet_dict
 
+
 # there must be sheets named "genome" and "hub"
 # Make the hub
 hub_dict = sheet_to_dict(file, sheet="hub")
 hub = trackhub.Hub(**hub_dict)
 
 # Make the genome
+# TODO: without assembly
 genome_dict = sheet_to_dict(file, sheet="genome")
 genome = trackhub.Assembly(**genome_dict)
 
@@ -43,97 +46,161 @@ trackdb = trackhub.TrackDb()
 genome.add_trackdb(trackdb)
 genomes_file.add_genome(genome)
 
+# we also need to create a trackDb and add it to the genome
+trackdb = trackhub.TrackDb()
+genome.add_trackdb(trackdb)
+
+# all_tracks =  add the genome to the genomes file here:
+genomes_file.add_genome(genome)
+
 sheets.remove("hub")
 sheets.remove("genome")
 
-# next loop through the config to make the containers
+all_super_tracks = {}
+all_composite_tracks = {}
+all_view_tracks = {}
+all_aggregate_tracks = {}
+
+if "super_config" in sheets:
+    # takes a data frame and returns a list of dictionaries
+    # the keys are the headers and the values are row values
+    list_of_super_tracks_as_dict = pd.read_excel(
+        file, sheet_name="super_config"
+    ).to_dict(orient="records")
+    for supertrack in list_of_super_tracks_as_dict:
+        supertrack_object = trackhub.SuperTrack(**supertrack)
+        all_super_tracks[supertrack["name"]] = supertrack_object
+        trackdb.add_tracks(supertrack_object)
+    if "composite_config" in sheets:
+        # takes a data frame and returns a list of dictionaries
+        # the keys are the headers and the values are row values
+        list_of_composite_tracks_as_dict = pd.read_excel(
+            file, sheet_name="composite_config"
+        ).to_dict(orient="records")
+        for composite in list_of_composite_tracks_as_dict:
+            supertrack = composite["super"]
+            del composite["super"]
+
+            compositetrack_object = trackhub.CompositeTrack(**composite)
+            all_composite_tracks[composite["name"]] = compositetrack_object
+            all_super_tracks[supertrack].add_tracks(compositetrack_object)
+    if "view_config" in sheets:
+        list_of_view_tracks_as_dict = pd.read_excel(
+            file, sheet_name="view_config"
+        ).to_dict(orient="records")
+        for view in list_of_view_tracks_as_dict:
+            compositetrack = view["composite"]
+            del view["composite"]
+            viewtrack_object = trackhub.ViewTrack(**view)
+            all_view_tracks[view["name"]] = viewtrack_object
+            all_composite_tracks[compositetrack].add_tracks(viewtrack_object)
+
+elif "composite_config" in sheets:
+    list_of_composite_tracks_as_dict = pd.read_excel(
+        file, sheet_name="composite_config"
+    ).to_dict(orient="records")
+    for composite in list_of_composite_tracks_as_dict:
+        compositetrack_object = trackhub.CompositeTrack(**composite)
+        all_composite_tracks[composite["name"]] = compositetrack_object
+        trackdb.add_tracks(compositetrack_object)
+    if "view_config" in sheets:
+        list_of_view_tracks_as_dict = pd.read_excel(
+            file, sheet_name="view_config"
+        ).to_dict(orient="records")
+        for view in list_of_view_tracks_as_dict:
+            #new_dict = {key: val for key, val in view.items() if key != "composite"}
+            comp = view["composite"]
+
+            del view["composite"]
+            viewtrack_object = trackhub.ViewTrack(**new_dict)
+            all_view_tracks[view["name"]] = viewtrack_object
+            all_composite_tracks[view[comp]].add_tracks(viewtrack_object)
+
+track_sheets = [item for item in sheets if "config" not in item]
+all_tracks_dict = []
+track_dicts = []
+for t in track_sheets:
+    #turns rows of sheet into list of dictionaries
+    track_dicts.extend(pd.read_excel(file, sheet_name=t).to_dict(orient="records"))
+
+def prepare_track_dict(track_dictionary):
+    new_dict = {}
+    for k,v in track_dictionary.items():
+        if not isinstance(v,str) and np.isnan(float(v)):
+            continue
+        else:
+            new_dict[k]=v
+    #print(new_dict)
+    parameters = trackhub.constants.track_fields[new_dict['tracktype']][:]
+    #print(parameters)
+    parameters.extend(trackhub.constants.track_fields['all'][:])
+    parameters.extend(["source", "tracktype","name"])
+    track_dict_new = {k:v for k,v in new_dict.items() if k in parameters}
+    #print(track_dict_new)
+    return track_dict_new
+#trackhub.Track(**track_dict_new)
+
+composite_to_subgroups_dict = {}
+track_to_subgroups = {}
+# iterate through all of the tracks
+subgroup_to_options={}
+for track_dict in track_dicts:
+    # add the track to the appropriate container
+    track = prepare_track_dict(track_dict)
+    track = trackhub.Track(**track)
+
+    if 'view' in track_dict:
+        all_view_tracks[track_dict['view']].add_tracks(track)
+    elif 'composite' in track_dict:
+        all_composite_tracks[track_dict['composite']].add_tracks(track)
+    elif 'supertrack' in track_dict:
+        all_super_tracks[track_dict['supertrack']].add_tracks(track)
+    else:
+        trackdb.add_tracks(track)
+
+    # here we are dealing with subgroups
+    subgroups_set = set()
+    # what about the case where there is a composite but no subgroups?
+    # subgroups are present in composite track. is there is no composite track define then there can be no subgroups
+    if 'composite' in track_dict:
+        subgroup_dict = {}
+        for k,v in track_dict.items():
+            # find items in dicitonary that start with subgroup
+            if "subgroup" in k:
+
+                new_subgroup = k.replace("subgroup_","")
+                #get the full set of subgroups for the track
+                if new_subgroup in subgroup_to_options:
+                    subgroup_to_options[new_subgroup].extend([v])
+                    subgroup_to_options[new_subgroup] = list(set(subgroup_to_options[new_subgroup]))
+                else:
+                    subgroup_to_options[new_subgroup] = [v]
+                #print(subgroup_to_options)
+                # keep track of subgroup and value for the track
+                subgroup_dict[new_subgroup] = v
+        if len(subgroup_dict) == 0:
+            continue
+        # add the full set of subgroups the a dictioary the converts composite to subgroups
+        # turn it into a list so it can be iterated on later
+        composite_to_subgroups_dict[track_dict['composite']] = subgroup_to_options
+        # add the dictionary pf subgroups to a dictionary that goes from track to subgroup
+        track_to_subgroups[track_dict['name']] = subgroup_dict
+
+for composite,subgroup_options in composite_to_subgroups_dict.items():
+    subgroups = []
+
+    for subgroup_name, options in subgroup_options.items():
+
+        mapping_dict = {group: group for group in subgroup_options}
+
+        s = trackhub.SubGroupDefinition(
+            name = subgroup_name,
+            label = subgroup_name,
+            mapping = mapping_dict)
+
+        subgroups.append(s)
+    all_composite_tracks[composite].add_subgroups(subgroups)
 
 
-f    elif sh=="bigbed":
-        bb = pd.read_excel(file, sheet_name=sh)
-        bb_d = dict(zip(bb.columns.values.tolist(),bb.iloc[0,:].tolist()))
-        bb_track = trackhub.Track(**bb_d)
-        trackdb.add_tracks(bb_track)
 
-    # if it's not a hub or a genome, then make a new track out of it
-    elif sh=="bigwig":
-        #what if there is no composite?
-        # new empy subgroup list for each track type
-        subgroups_list=[]
-        #how to remove the composite specific params and keep the track and vice versa
-        df = pd.read_excel(file, sheet_name=sh)
-        #subgroups = track_df.filter(regex='^subgroup', axis=1)
-
-        composite_list = df.composite.unique().tolist()
-        for c in composite_list:
-            composite_df = df[df['composite'] == c]
-            composite = composite_df[["composite", "visibility", "tracktype"]]
-            #track_df_no_composite = df.drop(track_df.filter(regex='composite|subgroup|super').columns, axis=1)
-                # get the header
-                # add only composite params
-            composite_params = list(composite.columns.values)
-            composite_dict = dict(zip(composite_params, composite.iloc[0,:].tolist()))
-            composite_dict['name'] = composite_dict['composite']+'_composite'
-            composite_dict.pop('composite')
-            composite = trackhub.CompositeTrack(**composite_dict)
-
-            view_list = composite_df.view.unique().tolist()
-
-            track_df = df.drop(df.filter(regex='composite').columns, axis=1)
-
-            subgroups = composite_df.filter(regex='^subgroup', axis=1)
-            sub = subgroups.columns.tolist()
-            for s in sub:
-                group = s.split('_', 1)[1]
-                a = list(set(subgroups[s].tolist()))
-                # for each columns make a sub group def
-                g = trackhub.SubGroupDefinition(
-                    name=group,
-                    label=group,
-                    mapping={r:r for r in a}
-                )
-                #add to the list of subgroups for the composite track
-                subgroups_list.append(g)
-            composite.add_subgroups(subgroups_list)
-            trackdb.add_tracks(composite)
-            for v in view_list:
-
-                view_df = df[df['view'] == v]
-                view = view_df[["view", "visibility", "tracktype"]]
-                # get the header
-                params = list(track_df.columns.values)
-                # add only view params
-                view_params = list(view.columns.values)
-                view_dict = dict(zip(view_params, view.iloc[0,:].tolist()))
-                view_dict['name'] = view_dict['view']+'_view'
-                view_track = trackhub.ViewTrack(**view_dict)
-                composite.add_view(view_track)
-                for index, row in view_df.iterrows():
-                    #print(index)
-                    track_df = df.drop(df.filter(regex='view|subgroup|composite').columns, axis=1)
-                    subgroups = df.filter(regex='^subgroup', axis=1)
-
-                    sub = subgroups.columns.tolist()
-                    new_names = list()
-                    for s in sub:
-                        group_name = s.split('_', 1)[1]
-                        new_names.append(group_name)
-                    sub_dict = dict(zip(new_names, subgroups.iloc[index,:].tolist()))
-                        # for each columns make a sub group def
-                                        #add to the list of subgroups for the composite track
-                    track_params = list(track_df.columns.values)
-                    track_info = dict(zip(track_params, track_df.iloc[index,:].tolist()))
-                    track_info['subgroups']=sub_dict
-                    if sub_dict["strand"] == "positive":
-                        track_info.pop('negateValues')
-
-                    track = trackhub.Track(**track_info)
-
-                    view_track.add_tracks(track)
-
-
-
-#"/data/NICHD-core0/datashare/storz/borrelia-bb0268/track_hub"
-s = file.split(".")[0]+"_staging"
-
-trackhub.upload.upload_hub(hub=hub, host="helix.nih.gov", remote_dir=destination, staging=s)
+# trackhub.upload.upload_hub(hub=hub, host="helix.nih.gov", remote_dir=destination, staging=s)

--- a/universal_trackhub.py
+++ b/universal_trackhub.py
@@ -8,10 +8,10 @@ from openpyxl import load_workbook
 import xlrd
 import sys
 
-# file = sys.argv[1]
+file = sys.argv[1]
 # destination = sys.argv[2]
 
-file = "universal_trackhub.xlsx"
+#file = "universal_trackhub.xlsx"
 
 # Get the sheet names from the Excel Workbook
 sheets = xlrd.open_workbook(file, on_demand=True).sheet_names()
@@ -233,5 +233,3 @@ for composite, subgroup_options in composite_to_subgroups_dict.items():
 
         subgroups.append(s)
     all_composite_tracks[composite].add_subgroups(subgroups)
-
-# trackhub.upload.upload_hub(hub=hub, host="helix.nih.gov", remote_dir=destination, staging=s)

--- a/universal_trackhub.py
+++ b/universal_trackhub.py
@@ -1,0 +1,139 @@
+import pandas as pd
+import trackhub
+#import argparse
+from openpyxl import load_workbook
+import xlrd
+import sys
+
+
+#excel_file = argparse.ArgumentParser(description='Process some integers.')
+#excel_file.add_argument('excel-file', metavar='e', type=str,nargs='?',help='path to excel file for track hub')
+#args = parser.parse_args()
+
+#file = sys.argv[1]
+
+file ='universal_trackhub.xlsx'
+
+#destination = sys.argv[2]
+
+#get the sheet names
+# there must be sheets named "genome" and "hub"
+# TODO: check that there are sheets names "genome" and "hub"
+sheets = xlrd.open_workbook(file, on_demand=True).sheet_names()
+
+
+def sheet_to_dict(file, sheet):
+    """ read a  two columns sheet and make it into a dictionary with the first column as keys and the second as the values"""
+    sheet = pd.read_excel(file, sheet_name=sheet, header=None)
+    sheet_dict = dict(sheet.values.tolist())
+    return sheet_dict
+
+# there must be sheets named "genome" and "hub"
+# Make the hub
+hub_dict = sheet_to_dict(file, sheet="hub")
+hub = trackhub.Hub(**hub_dict)
+
+# Make the genome
+genome_dict = sheet_to_dict(file, sheet="genome")
+genome = trackhub.Assembly(**genome_dict)
+
+genomes_file = trackhub.GenomesFile()
+hub.add_genomes_file(genomes_file)
+trackdb = trackhub.TrackDb()
+genome.add_trackdb(trackdb)
+genomes_file.add_genome(genome)
+
+sheets.remove("hub")
+sheets.remove("genome")
+
+# next loop through the config to make the containers
+
+
+f    elif sh=="bigbed":
+        bb = pd.read_excel(file, sheet_name=sh)
+        bb_d = dict(zip(bb.columns.values.tolist(),bb.iloc[0,:].tolist()))
+        bb_track = trackhub.Track(**bb_d)
+        trackdb.add_tracks(bb_track)
+
+    # if it's not a hub or a genome, then make a new track out of it
+    elif sh=="bigwig":
+        #what if there is no composite?
+        # new empy subgroup list for each track type
+        subgroups_list=[]
+        #how to remove the composite specific params and keep the track and vice versa
+        df = pd.read_excel(file, sheet_name=sh)
+        #subgroups = track_df.filter(regex='^subgroup', axis=1)
+
+        composite_list = df.composite.unique().tolist()
+        for c in composite_list:
+            composite_df = df[df['composite'] == c]
+            composite = composite_df[["composite", "visibility", "tracktype"]]
+            #track_df_no_composite = df.drop(track_df.filter(regex='composite|subgroup|super').columns, axis=1)
+                # get the header
+                # add only composite params
+            composite_params = list(composite.columns.values)
+            composite_dict = dict(zip(composite_params, composite.iloc[0,:].tolist()))
+            composite_dict['name'] = composite_dict['composite']+'_composite'
+            composite_dict.pop('composite')
+            composite = trackhub.CompositeTrack(**composite_dict)
+
+            view_list = composite_df.view.unique().tolist()
+
+            track_df = df.drop(df.filter(regex='composite').columns, axis=1)
+
+            subgroups = composite_df.filter(regex='^subgroup', axis=1)
+            sub = subgroups.columns.tolist()
+            for s in sub:
+                group = s.split('_', 1)[1]
+                a = list(set(subgroups[s].tolist()))
+                # for each columns make a sub group def
+                g = trackhub.SubGroupDefinition(
+                    name=group,
+                    label=group,
+                    mapping={r:r for r in a}
+                )
+                #add to the list of subgroups for the composite track
+                subgroups_list.append(g)
+            composite.add_subgroups(subgroups_list)
+            trackdb.add_tracks(composite)
+            for v in view_list:
+
+                view_df = df[df['view'] == v]
+                view = view_df[["view", "visibility", "tracktype"]]
+                # get the header
+                params = list(track_df.columns.values)
+                # add only view params
+                view_params = list(view.columns.values)
+                view_dict = dict(zip(view_params, view.iloc[0,:].tolist()))
+                view_dict['name'] = view_dict['view']+'_view'
+                view_track = trackhub.ViewTrack(**view_dict)
+                composite.add_view(view_track)
+                for index, row in view_df.iterrows():
+                    #print(index)
+                    track_df = df.drop(df.filter(regex='view|subgroup|composite').columns, axis=1)
+                    subgroups = df.filter(regex='^subgroup', axis=1)
+
+                    sub = subgroups.columns.tolist()
+                    new_names = list()
+                    for s in sub:
+                        group_name = s.split('_', 1)[1]
+                        new_names.append(group_name)
+                    sub_dict = dict(zip(new_names, subgroups.iloc[index,:].tolist()))
+                        # for each columns make a sub group def
+                                        #add to the list of subgroups for the composite track
+                    track_params = list(track_df.columns.values)
+                    track_info = dict(zip(track_params, track_df.iloc[index,:].tolist()))
+                    track_info['subgroups']=sub_dict
+                    if sub_dict["strand"] == "positive":
+                        track_info.pop('negateValues')
+
+                    track = trackhub.Track(**track_info)
+
+                    view_track.add_tracks(track)
+
+
+
+#"/data/NICHD-core0/datashare/storz/borrelia-bb0268/track_hub"
+s = file.split(".")[0]+"_staging"
+
+trackhub.upload.upload_hub(hub=hub, host="helix.nih.gov", remote_dir=destination, staging=s)


### PR DESCRIPTION
In order to ease the creation visualizations on the UCSC Genome Browser, I have written a script that will ingest an arbitrary Excel file and create the necessary files for a track hub. 

This script can handle simple to complex visualizations. The user defines the track hierarchy, subgroups, track fields, numerous track types, assembly hubs, and configuration of container tracks in an Excel file, rather than in a Python script.  

The Excel file must have the following specifications:
- A sheet called "hub"
- A sheet called "genome" (if using an assembly genome)
- Sheets that configure container tracks must be called "view_config", "aggregate_config", "super_config", and "composite_config"
- The user fills out required track fields in every sheet. 